### PR TITLE
Add MediaBrowserService sample with Android.bp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # android_bluetooth_test
-Android 14 Bluetooth stack test
+
+This repository contains a minimal sample demonstrating how to build a
+`MediaBrowserService`-based app using the Android 14 (API 34) build system with
+an `Android.bp` file.
+
+The sample exposes an empty `MediaBrowserService` and a basic `Activity` that
+connects to it. The `Android.bp` file describes an `android_app` module that can
+be included in an Android build tree.

--- a/app/Android.bp
+++ b/app/Android.bp
@@ -1,0 +1,9 @@
+android_app {
+    name: "MediaBrowserServiceSample",
+    srcs: ["src/**/*.java"],
+    resource_dirs: ["res"],
+    manifest: "AndroidManifest.xml",
+    sdk_version: "current",
+    min_sdk_version: "21",
+    target_sdk_version: "34",
+}

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.example.mediabrowserservice"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:label="@string/app_name">
+        <service android:name=".SimpleMediaBrowserService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService"/>
+            </intent-filter>
+        </service>
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/res/layout/activity_main.xml
+++ b/app/res/layout/activity_main.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_horizontal"
+    android:padding="16dp">
+    <TextView
+        android:id="@+id/state"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"
+        android:layout_marginBottom="16dp"/>
+    <Button
+        android:id="@+id/play"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/play"/>
+</LinearLayout>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">MediaBrowserServiceSample</string>
+    <string name="play">Play</string>
+</resources>

--- a/app/src/com/example/mediabrowserservice/MainActivity.java
+++ b/app/src/com/example/mediabrowserservice/MainActivity.java
@@ -1,0 +1,85 @@
+package com.example.mediabrowserservice;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.media.browse.MediaBrowser;
+import android.media.session.MediaController;
+import android.media.session.MediaSession;
+import android.media.session.PlaybackState;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+/**
+ * Activity that connects to {@link SimpleMediaBrowserService} and displays the current playback
+ * state. This demonstrates how a client would interact with the service using a
+ * {@link MediaBrowser} and {@link MediaController}.
+ */
+public class MainActivity extends Activity {
+    private MediaBrowser mBrowser;
+    private MediaController mController;
+    private TextView mState;
+
+    private final MediaBrowser.ConnectionCallback mConnectionCallback =
+            new MediaBrowser.ConnectionCallback() {
+                @Override
+                public void onConnected() {
+                    MediaSession.Token token = mBrowser.getSessionToken();
+                    mController = new MediaController(MainActivity.this, token);
+                    mController.registerCallback(mControllerCallback);
+                    updateState(mController.getPlaybackState());
+                }
+            };
+
+    private final MediaController.Callback mControllerCallback =
+            new MediaController.Callback() {
+                @Override
+                public void onPlaybackStateChanged(PlaybackState state) {
+                    updateState(state);
+                }
+            };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        mState = findViewById(R.id.state);
+        Button play = findViewById(R.id.play);
+        play.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mController != null) {
+                    mController.getTransportControls().play();
+                }
+            }
+        });
+
+        mBrowser = new MediaBrowser(this, new ComponentName(this, SimpleMediaBrowserService.class),
+                mConnectionCallback, null);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        mBrowser.connect();
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        if (mController != null) {
+            mController.unregisterCallback(mControllerCallback);
+            mController = null;
+        }
+        mBrowser.disconnect();
+    }
+
+    private void updateState(PlaybackState state) {
+        if (state == null) {
+            mState.setText("No state");
+        } else {
+            mState.setText("State: " + state.getState());
+        }
+    }
+}

--- a/app/src/com/example/mediabrowserservice/SimpleMediaBrowserService.java
+++ b/app/src/com/example/mediabrowserservice/SimpleMediaBrowserService.java
@@ -1,0 +1,37 @@
+package com.example.mediabrowserservice;
+
+import android.media.browse.MediaBrowser;
+import android.media.browse.MediaBrowser.MediaItem;
+import android.media.session.MediaSession;
+import android.os.Bundle;
+import android.service.media.MediaBrowserService;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A minimal {@link MediaBrowserService} implementation that exposes an empty media catalog.
+ * This service sets up a {@link MediaSession} so clients can connect using {@link MediaBrowser}.
+ */
+public class SimpleMediaBrowserService extends MediaBrowserService {
+    private MediaSession mSession;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        mSession = new MediaSession(this, "SimpleMediaBrowserService");
+        setSessionToken(mSession.getSessionToken());
+    }
+
+    @Override
+    public BrowserRoot onGetRoot(String clientPackageName, int clientUid, Bundle rootHints) {
+        // Allow all clients to connect and browse the single "root" node.
+        return new BrowserRoot("root", /*extras=*/ null);
+    }
+
+    @Override
+    public void onLoadChildren(String parentId, Result<List<MediaItem>> result) {
+        // Return an empty list since this sample does not provide media content.
+        result.sendResult(Collections.emptyList());
+    }
+}


### PR DESCRIPTION
## Summary
- Add minimal MediaBrowserService implementation and connecting activity
- Provide resources and manifest for a buildable Android app
- Introduce Android.bp defining an android_app module targeting API 34

## Testing
- `javac $(find app/src -name '*.java')` *(fails: package android.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689b2b5942b88325bdf94e69f2b7750d