### PR TITLE
Add Bluetooth A2DP media player sample

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,11 @@
+android_app {
+    name: "BluetoothMediaPlayer",
+    manifest: "AndroidManifest.xml",
+    srcs: ["src/**/*.java"],
+    resource_dirs: ["res"],
+    certificate: "platform",
+    sdk_version: "33",
+    min_sdk_version: "33",
+    target_sdk_version: "33",
+    // Uses platform audio and media session APIs only, so no additional static libs are required.
+}

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.android">
+
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application
+        android:allowBackup="true"
+        android:label="Bluetooth Player"
+        android:icon="@drawable/ic_album_placeholder"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="Bluetooth Player"
+            android:theme="@style/AppTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name=".PlaybackService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback">
+            <intent-filter>
+                <action android:name="com.example.android.action.PLAY" />
+                <action android:name="com.example.android.action.PAUSE" />
+                <action android:name="com.example.android.action.NEXT" />
+                <action android:name="com.example.android.action.PREV" />
+                <action android:name="com.example.android.action.FAST_FORWARD" />
+                <action android:name="com.example.android.action.REWIND" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/res/drawable/ic_album_placeholder.xml
+++ b/res/drawable/ic_album_placeholder.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="#3F51B5"
+        android:pathData="M4,8c0,-2.21 1.79,-4 4,-4h32c2.21,0 4,1.79 4,4v32c0,2.21 -1.79,4 -4,4H8c-2.21,0 -4,-1.79 -4,-4z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M24,14a10,10 0 1,0 0,20a10,10 0 1,0 0,-20zm0,4a6,6 0 1,1 0,12a6,6 0 1,1 0,-12zm-4.5,-7a2.5,2.5 0 1,0 0,5a2.5,2.5 0 1,0 0,-5z" />
+</vector>

--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <ImageView
+        android:id="@+id/image_album_art"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:layout_gravity="center_horizontal"
+        android:contentDescription="@string/album_art_description"
+        android:src="@drawable/ic_album_placeholder" />
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:textAppearance="@android:style/TextAppearance.Material.Large"
+        android:textStyle="bold"
+        android:text="@string/app_name" />
+
+    <TextView
+        android:id="@+id/text_subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textAppearance="@android:style/TextAppearance.Material.Medium"
+        android:text="@string/subtitle_hint" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <ImageButton
+            android:id="@+id/button_rew"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/action_rewind"
+            android:src="@android:drawable/ic_media_rew" />
+
+        <ImageButton
+            android:id="@+id/button_prev"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/action_prev"
+            android:src="@android:drawable/ic_media_previous" />
+
+        <ImageButton
+            android:id="@+id/button_play_pause"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/action_play"
+            android:src="@android:drawable/ic_media_play" />
+
+        <ImageButton
+            android:id="@+id/button_next"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/action_next"
+            android:src="@android:drawable/ic_media_next" />
+
+        <ImageButton
+            android:id="@+id/button_ff"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/action_fast_forward"
+            android:src="@android:drawable/ic_media_ff" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="album_art_size">256dp</dimen>
+</resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Bluetooth Player</string>
+    <string name="subtitle_hint">Connect an A2DP device and press play</string>
+    <string name="action_play">Play</string>
+    <string name="action_pause">Pause</string>
+    <string name="action_next">Next</string>
+    <string name="action_prev">Previous</string>
+    <string name="action_fast_forward">Fast Forward</string>
+    <string name="action_rewind">Rewind</string>
+    <string name="album_art_description">Album artwork</string>
+    <string name="notification_channel_name">Bluetooth Playback</string>
+    <string name="notification_channel_description">Media controls for Bluetooth playback</string>
+</resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="@android:style/Theme.Material.Light">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/src/com/example/android/MainActivity.java
+++ b/src/com/example/android/MainActivity.java
@@ -1,0 +1,177 @@
+package com.example.android;
+
+import android.Manifest;
+import android.annotation.Nullable;
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.content.pm.PackageManager;
+import android.media.session.MediaController;
+import android.media.session.PlaybackState;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+public class MainActivity extends Activity {
+
+    private MediaController mediaController;
+    private PlaybackService playbackService;
+    private ImageButton playPauseButton;
+    private ImageButton nextButton;
+    private ImageButton prevButton;
+    private ImageButton ffButton;
+    private ImageButton rewButton;
+    private TextView titleView;
+    private TextView subtitleView;
+    private ImageView albumArtView;
+
+    private final ServiceConnection connection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service) {
+            PlaybackService.LocalBinder binder = (PlaybackService.LocalBinder) service;
+            playbackService = binder.getService();
+            mediaController = new MediaController(MainActivity.this, binder.getSessionToken());
+            mediaController.registerCallback(controllerCallback);
+            updateFromController();
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            if (mediaController != null) {
+                mediaController.unregisterCallback(controllerCallback);
+                mediaController = null;
+            }
+            playbackService = null;
+        }
+    };
+
+    private final MediaController.Callback controllerCallback = new MediaController.Callback() {
+        @Override
+        public void onPlaybackStateChanged(PlaybackState state) {
+            updatePlayPause(state != null && state.getState() == PlaybackState.STATE_PLAYING);
+        }
+
+        @Override
+        public void onMetadataChanged(android.media.MediaMetadata metadata) {
+            updateMetadata(metadata);
+        }
+    };
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        initViews();
+        requestNotificationPermissionIfNeeded();
+        Intent intent = new Intent(this, PlaybackService.class);
+        startService(intent);
+        bindService(intent, connection, Context.BIND_AUTO_CREATE);
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (mediaController != null) {
+            mediaController.unregisterCallback(controllerCallback);
+        }
+        unbindService(connection);
+        super.onDestroy();
+    }
+
+    private void initViews() {
+        playPauseButton = findViewById(R.id.button_play_pause);
+        nextButton = findViewById(R.id.button_next);
+        prevButton = findViewById(R.id.button_prev);
+        ffButton = findViewById(R.id.button_ff);
+        rewButton = findViewById(R.id.button_rew);
+        titleView = findViewById(R.id.text_title);
+        subtitleView = findViewById(R.id.text_subtitle);
+        albumArtView = findViewById(R.id.image_album_art);
+
+        playPauseButton.setOnClickListener(v -> togglePlayback());
+        nextButton.setOnClickListener(v -> sendAction(PlaybackService.ACTION_NEXT));
+        prevButton.setOnClickListener(v -> sendAction(PlaybackService.ACTION_PREV));
+        ffButton.setOnClickListener(v -> sendAction(PlaybackService.ACTION_FAST_FORWARD));
+        rewButton.setOnClickListener(v -> sendAction(PlaybackService.ACTION_REWIND));
+    }
+
+    private void togglePlayback() {
+        if (mediaController == null) {
+            return;
+        }
+        PlaybackState state = mediaController.getPlaybackState();
+        if (state == null || state.getState() != PlaybackState.STATE_PLAYING) {
+            sendAction(PlaybackService.ACTION_PLAY);
+        } else {
+            sendAction(PlaybackService.ACTION_PAUSE);
+        }
+    }
+
+    private void sendAction(String action) {
+        if (mediaController == null) {
+            return;
+        }
+        switch (action) {
+            case PlaybackService.ACTION_PLAY:
+                mediaController.getTransportControls().play();
+                break;
+            case PlaybackService.ACTION_PAUSE:
+                mediaController.getTransportControls().pause();
+                break;
+            case PlaybackService.ACTION_NEXT:
+                mediaController.getTransportControls().skipToNext();
+                break;
+            case PlaybackService.ACTION_PREV:
+                mediaController.getTransportControls().skipToPrevious();
+                break;
+            case PlaybackService.ACTION_FAST_FORWARD:
+                mediaController.getTransportControls().fastForward();
+                break;
+            case PlaybackService.ACTION_REWIND:
+                mediaController.getTransportControls().rewind();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void updateFromController() {
+        if (mediaController == null) {
+            return;
+        }
+        PlaybackState state = mediaController.getPlaybackState();
+        updatePlayPause(state != null && state.getState() == PlaybackState.STATE_PLAYING);
+        updateMetadata(mediaController.getMetadata());
+    }
+
+    private void updatePlayPause(boolean playing) {
+        playPauseButton.setImageResource(playing ? android.R.drawable.ic_media_pause : android.R.drawable.ic_media_play);
+    }
+
+    private void updateMetadata(@Nullable android.media.MediaMetadata metadata) {
+        if (metadata == null) {
+            titleView.setText(R.string.app_name);
+            subtitleView.setText(R.string.subtitle_hint);
+            albumArtView.setImageResource(R.drawable.ic_album_placeholder);
+            return;
+        }
+        titleView.setText(metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE));
+        String subtitle = metadata.getString(android.media.MediaMetadata.METADATA_KEY_ARTIST)
+                + " • "
+                + metadata.getString(android.media.MediaMetadata.METADATA_KEY_ALBUM);
+        subtitleView.setText(subtitle);
+        albumArtView.setImageBitmap(metadata.getBitmap(android.media.MediaMetadata.METADATA_KEY_ART));
+    }
+
+    private void requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, 1001);
+            }
+        }
+    }
+}

--- a/src/com/example/android/PlaybackEngine.java
+++ b/src/com/example/android/PlaybackEngine.java
@@ -1,0 +1,194 @@
+package com.example.android;
+
+import android.media.AudioAttributes;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioTrack;
+import android.os.SystemClock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Generates simple sine wave audio so the player can drive A2DP devices without bundling assets.
+ */
+class PlaybackEngine {
+    static class TrackInfo {
+        final String title;
+        final String artist;
+        final String album;
+        final String fileName;
+        final long durationMs;
+
+        TrackInfo(String title, String artist, String album, String fileName, long durationMs) {
+            this.title = title;
+            this.artist = artist;
+            this.album = album;
+            this.fileName = fileName;
+            this.durationMs = durationMs;
+        }
+    }
+
+    interface Listener {
+        void onTrackChanged(TrackInfo trackInfo);
+    }
+
+    private static final int SAMPLE_RATE = 44_100;
+    private static final int CHANNEL_CONFIG = AudioFormat.CHANNEL_OUT_STEREO;
+    private static final int ENCODING = AudioFormat.ENCODING_PCM_16BIT;
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final List<TrackInfo> playlist = new ArrayList<>();
+    private final Listener listener;
+
+    private int trackIndex = 0;
+    private boolean playing;
+    private long playbackStartRealtime;
+    private long playbackStartPosition;
+    private Future<?> playbackFuture;
+
+    PlaybackEngine(Listener listener) {
+        this.listener = listener;
+        playlist.add(new TrackInfo("Sample Track One", "Example Artist", "Demo Album", "sample_one.wav", 180_000));
+        playlist.add(new TrackInfo("Sample Track Two", "Example Artist", "Demo Album", "sample_two.wav", 200_000));
+        playlist.add(new TrackInfo("Extended Mix", "Example Artist", "Live Session", "extended_mix.wav", 240_000));
+    }
+
+    TrackInfo currentTrack() {
+        return playlist.get(trackIndex);
+    }
+
+    void play() {
+        if (playing) {
+            return;
+        }
+        playing = true;
+        playbackStartRealtime = SystemClock.elapsedRealtime();
+        startTone();
+    }
+
+    void pause() {
+        playing = false;
+        stopTone();
+        playbackStartPosition = getPositionInternal();
+    }
+
+    void stop() {
+        playing = false;
+        stopTone();
+        playbackStartPosition = 0;
+    }
+
+    void skipToNext() {
+        trackIndex = (trackIndex + 1) % playlist.size();
+        resetPosition();
+    }
+
+    void skipToPrevious() {
+        trackIndex = (trackIndex - 1 + playlist.size()) % playlist.size();
+        resetPosition();
+    }
+
+    void fastForward() {
+        seekTo(Math.min(currentTrack().durationMs, getPosition() + 10_000));
+    }
+
+    void rewind() {
+        seekTo(Math.max(0, getPosition() - 10_000));
+    }
+
+    void seekTo(long positionMs) {
+        playbackStartPosition = positionMs;
+        playbackStartRealtime = SystemClock.elapsedRealtime();
+    }
+
+    long getPosition() {
+        return getPositionInternal();
+    }
+
+    boolean isPlaying() {
+        return playing;
+    }
+
+    private void resetPosition() {
+        playbackStartPosition = 0;
+        playbackStartRealtime = SystemClock.elapsedRealtime();
+        if (listener != null) {
+            listener.onTrackChanged(currentTrack());
+        }
+        if (playing) {
+            restartTone();
+        }
+    }
+
+    private long getPositionInternal() {
+        if (!playing) {
+            return playbackStartPosition;
+        }
+        long elapsed = SystemClock.elapsedRealtime() - playbackStartRealtime;
+        long position = playbackStartPosition + elapsed;
+        return Math.min(position, currentTrack().durationMs);
+    }
+
+    private void restartTone() {
+        stopTone();
+        startTone();
+    }
+
+    private void startTone() {
+        playbackFuture = executor.submit(() -> {
+            int bufferSize = AudioTrack.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, ENCODING);
+            if (bufferSize <= 0) {
+                bufferSize = SAMPLE_RATE; // Fallback to a second of audio data.
+            }
+            AudioTrack track = new AudioTrack(
+                    new AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_MEDIA)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                            .build(),
+                    new AudioFormat.Builder()
+                            .setEncoding(ENCODING)
+                            .setSampleRate(SAMPLE_RATE)
+                            .setChannelMask(CHANNEL_CONFIG)
+                            .build(),
+                    bufferSize,
+                    AudioTrack.MODE_STREAM,
+                    AudioManager.AUDIO_SESSION_ID_GENERATE);
+            track.play();
+
+            short[] buffer = new short[bufferSize];
+            double frequency = 880.0; // Audible tone suitable for debugging A2DP paths.
+            double increment = 2 * Math.PI * frequency / SAMPLE_RATE;
+            int idx = 0;
+            while (playing && !Thread.currentThread().isInterrupted()) {
+                for (int i = 0; i < buffer.length; i += 2) {
+                    short sample = (short) (Math.sin(idx * increment) * Short.MAX_VALUE * 0.2);
+                    buffer[i] = sample;
+                    buffer[i + 1] = sample;
+                    idx++;
+                }
+                track.write(buffer, 0, buffer.length);
+                if (getPositionInternal() >= currentTrack().durationMs) {
+                    skipToNext();
+                }
+            }
+            track.stop();
+            track.release();
+        });
+    }
+
+    private void stopTone() {
+        if (playbackFuture != null) {
+            playbackFuture.cancel(true);
+            playbackFuture = null;
+        }
+    }
+
+    void release() {
+        stop();
+        executor.shutdownNow();
+    }
+}

--- a/src/com/example/android/PlaybackService.java
+++ b/src/com/example/android/PlaybackService.java
@@ -1,0 +1,273 @@
+package com.example.android;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.media.session.MediaController;
+import android.media.session.MediaSession;
+import android.media.session.PlaybackState;
+import android.os.Binder;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.SystemClock;
+
+import java.util.Locale;
+
+public class PlaybackService extends Service implements PlaybackEngine.Listener {
+
+    public static final String ACTION_PLAY = "com.example.android.action.PLAY";
+    public static final String ACTION_PAUSE = "com.example.android.action.PAUSE";
+    public static final String ACTION_NEXT = "com.example.android.action.NEXT";
+    public static final String ACTION_PREV = "com.example.android.action.PREV";
+    public static final String ACTION_FAST_FORWARD = "com.example.android.action.FAST_FORWARD";
+    public static final String ACTION_REWIND = "com.example.android.action.REWIND";
+
+    private static final String CHANNEL_ID = "bluetooth_player_channel";
+    private static final int NOTIFICATION_ID = 1001;
+
+    private final IBinder binder = new LocalBinder();
+    private MediaSession mediaSession;
+    private MediaController mediaController;
+    private PlaybackEngine playbackEngine;
+    private Handler progressHandler;
+
+    public class LocalBinder extends Binder {
+        PlaybackService getService() {
+            return PlaybackService.this;
+        }
+
+        MediaSession.Token getSessionToken() {
+            return mediaSession.getSessionToken();
+        }
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        playbackEngine = new PlaybackEngine(this);
+        progressHandler = new Handler(Looper.getMainLooper());
+        setupMediaSession();
+        createNotificationChannel();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null && intent.getAction() != null) {
+            handleIntent(intent.getAction());
+        }
+        startForeground(NOTIFICATION_ID, buildNotification());
+        return START_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return binder;
+    }
+
+    @Override
+    public void onDestroy() {
+        progressHandler.removeCallbacksAndMessages(null);
+        playbackEngine.release();
+        mediaSession.release();
+        super.onDestroy();
+    }
+
+    private void setupMediaSession() {
+        mediaSession = new MediaSession(this, "BluetoothPlayerSession");
+        mediaSession.setCallback(new MediaSession.Callback() {
+            @Override
+            public void onPlay() {
+                playbackEngine.play();
+                updateSessionState(PlaybackState.STATE_PLAYING);
+                startForeground(NOTIFICATION_ID, buildNotification());
+            }
+
+            @Override
+            public void onPause() {
+                playbackEngine.pause();
+                updateSessionState(PlaybackState.STATE_PAUSED);
+                stopForeground(false);
+            }
+
+            @Override
+            public void onSkipToNext() {
+                playbackEngine.skipToNext();
+                updateMetadata();
+                updateSessionState(playbackEngine.isPlaying() ? PlaybackState.STATE_PLAYING : PlaybackState.STATE_PAUSED);
+            }
+
+            @Override
+            public void onSkipToPrevious() {
+                playbackEngine.skipToPrevious();
+                updateMetadata();
+                updateSessionState(playbackEngine.isPlaying() ? PlaybackState.STATE_PLAYING : PlaybackState.STATE_PAUSED);
+            }
+
+            @Override
+            public void onFastForward() {
+                playbackEngine.fastForward();
+                updateSessionState(playbackEngine.isPlaying() ? PlaybackState.STATE_PLAYING : PlaybackState.STATE_PAUSED);
+            }
+
+            @Override
+            public void onRewind() {
+                playbackEngine.rewind();
+                updateSessionState(playbackEngine.isPlaying() ? PlaybackState.STATE_PLAYING : PlaybackState.STATE_PAUSED);
+            }
+
+            @Override
+            public void onSeekTo(long pos) {
+                playbackEngine.seekTo(pos);
+                updateSessionState(playbackEngine.isPlaying() ? PlaybackState.STATE_PLAYING : PlaybackState.STATE_PAUSED);
+            }
+        });
+        mediaSession.setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS | MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS);
+        mediaSession.setActive(true);
+        mediaController = new MediaController(this, mediaSession.getSessionToken());
+        updateMetadata();
+        updateSessionState(PlaybackState.STATE_PAUSED);
+        scheduleProgressUpdate();
+    }
+
+    private void handleIntent(String action) {
+        if (ACTION_PLAY.equals(action)) {
+            mediaController.getTransportControls().play();
+        } else if (ACTION_PAUSE.equals(action)) {
+            mediaController.getTransportControls().pause();
+        } else if (ACTION_NEXT.equals(action)) {
+            mediaController.getTransportControls().skipToNext();
+        } else if (ACTION_PREV.equals(action)) {
+            mediaController.getTransportControls().skipToPrevious();
+        } else if (ACTION_FAST_FORWARD.equals(action)) {
+            mediaController.getTransportControls().fastForward();
+        } else if (ACTION_REWIND.equals(action)) {
+            mediaController.getTransportControls().rewind();
+        }
+    }
+
+    private PendingIntent buildPendingIntent(String action) {
+        Intent intent = new Intent(this, PlaybackService.class);
+        intent.setAction(action);
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+        return PendingIntent.getService(this, action.hashCode(), intent, flags);
+    }
+
+    private Notification buildNotification() {
+        PlaybackEngine.TrackInfo trackInfo = playbackEngine.currentTrack();
+        boolean playing = playbackEngine.isPlaying();
+
+        Notification.Builder builder = new Notification.Builder(this, CHANNEL_ID)
+                .setContentTitle(trackInfo.title)
+                .setContentText(String.format(Locale.getDefault(), "%s • %s", trackInfo.artist, trackInfo.album))
+                .setSmallIcon(android.R.drawable.ic_media_play)
+                .setLargeIcon(createAlbumArt(trackInfo))
+                .setOngoing(playing)
+                .setShowWhen(false)
+                .setVisibility(Notification.VISIBILITY_PUBLIC)
+                .setStyle(new Notification.MediaStyle()
+                        .setMediaSession(mediaSession.getSessionToken())
+                        .setShowActionsInCompactView(0, 1, 2));
+
+        builder.addAction(new Notification.Action.Builder(
+                android.R.drawable.ic_media_previous,
+                getString(R.string.action_prev),
+                buildPendingIntent(ACTION_PREV)).build());
+
+        builder.addAction(new Notification.Action.Builder(
+                playing ? android.R.drawable.ic_media_pause : android.R.drawable.ic_media_play,
+                playing ? getString(R.string.action_pause) : getString(R.string.action_play),
+                buildPendingIntent(playing ? ACTION_PAUSE : ACTION_PLAY)).build());
+
+        builder.addAction(new Notification.Action.Builder(
+                android.R.drawable.ic_media_next,
+                getString(R.string.action_next),
+                buildPendingIntent(ACTION_NEXT)).build());
+
+        return builder.build();
+    }
+
+    private void updateMetadata() {
+        PlaybackEngine.TrackInfo trackInfo = playbackEngine.currentTrack();
+        mediaSession.setMetadata(new android.media.MediaMetadata.Builder()
+                .putString(android.media.MediaMetadata.METADATA_KEY_TITLE, trackInfo.title)
+                .putString(android.media.MediaMetadata.METADATA_KEY_ARTIST, trackInfo.artist)
+                .putString(android.media.MediaMetadata.METADATA_KEY_ALBUM, trackInfo.album)
+                .putString(android.media.MediaMetadata.METADATA_KEY_MEDIA_ID, trackInfo.fileName)
+                .putLong(android.media.MediaMetadata.METADATA_KEY_DURATION, trackInfo.durationMs)
+                .putBitmap(android.media.MediaMetadata.METADATA_KEY_ART, createAlbumArt(trackInfo))
+                .build());
+    }
+
+    private void updateSessionState(int state) {
+        PlaybackState playbackState = new PlaybackState.Builder()
+                .setActions(
+                        PlaybackState.ACTION_PLAY
+                                | PlaybackState.ACTION_PAUSE
+                                | PlaybackState.ACTION_PLAY_PAUSE
+                                | PlaybackState.ACTION_SKIP_TO_NEXT
+                                | PlaybackState.ACTION_SKIP_TO_PREVIOUS
+                                | PlaybackState.ACTION_FAST_FORWARD
+                                | PlaybackState.ACTION_REWIND
+                                | PlaybackState.ACTION_SEEK_TO)
+                .setState(state, playbackEngine.getPosition(), 1.0f, SystemClock.elapsedRealtime())
+                .build();
+        mediaSession.setPlaybackState(playbackState);
+        mediaSession.setActive(true);
+    }
+
+    private void scheduleProgressUpdate() {
+        progressHandler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                updateSessionState(playbackEngine.isPlaying() ? PlaybackState.STATE_PLAYING : PlaybackState.STATE_PAUSED);
+                scheduleProgressUpdate();
+            }
+        }, 1000);
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID,
+                    getString(R.string.notification_channel_name),
+                    NotificationManager.IMPORTANCE_LOW);
+            channel.setDescription(getString(R.string.notification_channel_description));
+            NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            manager.createNotificationChannel(channel);
+        }
+    }
+
+    private Bitmap createAlbumArt(PlaybackEngine.TrackInfo trackInfo) {
+        int size = getResources().getDimensionPixelSize(R.dimen.album_art_size);
+        Bitmap bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        paint.setColor(Color.parseColor("#3F51B5"));
+        canvas.drawRoundRect(new RectF(0, 0, size, size), 24f, 24f, paint);
+
+        paint.setColor(Color.WHITE);
+        paint.setTextAlign(Paint.Align.CENTER);
+        paint.setTextSize(size / 6f);
+        float x = size / 2f;
+        float y = size / 2f - ((paint.descent() + paint.ascent()) / 2);
+        canvas.drawText(trackInfo.title, x, y, paint);
+        return bitmap;
+    }
+
+    @Override
+    public void onTrackChanged(PlaybackEngine.TrackInfo trackInfo) {
+        updateMetadata();
+        startForeground(NOTIFICATION_ID, buildNotification());
+    }
+}


### PR DESCRIPTION
## Summary
- add an Android.bp packaged as `BluetoothMediaPlayer` targeting Android 13
- implement a media session–backed playback service with synthetic audio output and transport controls for Bluetooth A2DP
- add an activity UI and resources to surface metadata, cover art, and playback controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930f9aa4dc08325aad1a4f3262e7ac5)